### PR TITLE
Gitlab ci branch select

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,11 @@ build_base:
     - cd ..
     - git clone https://github.com/esa/nanosat-mo-framework.git
     - cd nanosat-mo-framework
+    - if [ $NMF_BRANCH = "dev" ] && [ -n "$(git branch --list $CI_COMMIT_REF_NAME)" ]; then
+    - git checkout $CI_COMMIT_REF_NAME
+    - else
     - git checkout $NMF_BRANCH
+    - fi
     - mvn clean install
     - cd ..
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,7 @@ build_base:
     - cd ..
     - git clone https://github.com/esa/nanosat-mo-framework.git
     - cd nanosat-mo-framework
-    - git checkout dev
+    - git checkout $NMF_BRANCH
     - mvn clean install
     - cd ..
   artifacts:


### PR DESCRIPTION
Automaticaly selects branch of same name from NMF if it exists, else uses the dev branch.