### PR TITLE
Ipk size fix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@ stages:
   - build_nmf_opssat
   - deploy
   - deploy_extras
-
+  - build_ipk
 image: maven:3.3.9-jdk-8
 
 variables:
@@ -33,6 +33,18 @@ build_base:
     paths:
       - $NMF_HOME/.m2/repository
       - $NMF_HOME/nanosat-mo-framework/mission/simulator/opssat-spacecraft-simulator/platformsim.properties
+    expire_in: 1 day
+
+build_ipk:
+  stage: build_ipk
+  only:
+    variables:
+       - $IPK == "1"
+  script:
+    - mvn clean install -Pipk-build
+  artifacts:
+    paths:
+      - $NMF_HOME/opssat-package/target/
     expire_in: 1 day
 
 build_ground:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,8 +20,10 @@ build_base:
     - cd ..
     - git clone https://github.com/esa/nanosat-mo-framework.git
     - cd nanosat-mo-framework
-    - if [ $NMF_BRANCH = "dev" ] && [ -n "$(git branch --list $CI_COMMIT_REF_NAME)" ]; then
+    - if [ "$NMF_BRANCH" = "dev" ] && [[ $(git ls-remote --heads origin $CI_COMMIT_REF_NAME) ]]; then
     - git checkout $CI_COMMIT_REF_NAME
+    - elif [ "$NMF_BRANCH" = "" ]; then
+    - git checkout dev
     - else
     - git checkout $NMF_BRANCH
     - fi

--- a/opssat-package/pom.xml
+++ b/opssat-package/pom.xml
@@ -64,6 +64,22 @@
   </properties>
   <profiles>
     <profile>
+      <id>ipk-build</id>
+      <dependencies>
+        <dependency>
+          <groupId>int.esa.nmf.core</groupId>
+          <artifactId>nanosat-mo-supervisor</artifactId>
+          <version>${project.version}</version>
+          <exclusions>
+            <exclusion>
+      	      <groupId>int.esa.nmf.mission.simulator.moservices.impl</groupId>
+              <artifactId>nmf-platform-impl-sim</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+    </dependencies>
+    </profile>
+    <profile>
       <id>ground</id>
       <properties>
         <isGround>true</isGround>
@@ -151,6 +167,12 @@
       <groupId>int.esa.nmf.core</groupId>
       <artifactId>nanosat-mo-supervisor</artifactId>
       <version>${project.version}</version>
+      <!--exclusions>
+         <exclusion>
+    	     <groupId>int.esa.nmf.mission.simulator.moservices.impl</groupId>
+        	 <artifactId>nmf-platform-impl-sim</artifactId>
+ 	     </exclusion>
+      </exclusions-->
     </dependency>
     <dependency>
       <groupId>int.esa.nmf.sdk.examples.space</groupId>


### PR DESCRIPTION
adds a new stage to the build process in gitlab ci which builds the .ipk file without the simulator and its dependencies.
This results in a strong size reduction of the ipk file.
File can be downloaded as artefact

(auto_branchselect_fix needed)