### PR TITLE
Feature #489: Establish mechanism for accessing OBSW Datapool through the NMF

### DIFF
--- a/nanomind-connector/parameters-provisioning/pom.xml
+++ b/nanomind-connector/parameters-provisioning/pom.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+  <!--
+    Licensed under European Space Agency Public License (ESA-PL) Weak Copyleft – v2.4
+    You may not use this file except in compliance with the License.
+
+    Except as expressly set forth in this License, the Software is provided to
+    You on an "as is" basis and without warranties of any kind, including without
+    limitation merchantability, fitness for a particular purpose, absence of
+    defects or errors, accuracy or non-infringement of intellectual property rights.
+ 
+    See the License for the specific language governing permissions and limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  
+  <parent>
+    <groupId>int.esa.nmf.mission.opssat</groupId>
+    <artifactId>parent</artifactId>
+    <version>2.1.0-SNAPSHOT</version>
+    <relativePath>../../parent/pom.xml</relativePath>
+  </parent>
+  
+  <groupId>int.esa.nmf.mission.opssat.nanomind</groupId>
+  <artifactId>parameters-provisioning</artifactId>
+  <packaging>jar</packaging>
+
+  <name>ESA NMF Mission OPS-SAT - Nanomind OBSW parameters provisioning</name>
+  <description>
+    Provides OBSW parameter values by consuming the Nanomind aggregation service in a
+    smart way to avoid overloading the Nanomind
+  </description>
+  <url>http://www.esa.int</url>
+  
+  <organization>
+    <name>ESA</name>
+    <url>http://www.esa.int</url>
+  </organization>
+
+  <licenses>
+    <license>
+      <name>European Space Agency Public License (ESA-PL) Weak Copyleft – v2.4</name>
+      <url>https://raw.github.com/esa/CCSDS_APPS/master/LICENCE.md</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  
+  <scm>
+    <connection>scm:git:git@github.com:esa/CCSDS_APPS.git</connection>
+    <developerConnection>scm:git:git@github.com:esa/CCSDS_APPS.git</developerConnection>
+    <url>https://github.com/esa/CCSDS_APPS</url>
+  </scm>
+  
+  <issueManagement>
+    <system>GitHub</system>
+    <url>https://github.com/CesarCoelho/BUG_REPORTS_NANOSAT_MO_FRAMEWORK/issues</url>
+  </issueManagement>
+  
+  <developers>
+    <developer>
+      <id>TanguySoto</id>
+      <name>Tanguy Soto</name>
+      <url>https://github.com/TanguySoto</url>
+    </developer>
+  </developers>
+
+  <dependencies>
+    <dependency>
+      <groupId>int.esa.nmf.core</groupId>
+      <artifactId>helper-tools</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>int.esa.nmf.mission.opssat.nanomind</groupId>
+      <artifactId>consumers</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>int.esa.nmf.core</groupId>
+      <artifactId>nanosat-mo-supervisor</artifactId>
+    </dependency>
+  </dependencies>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/nanomind-connector/parameters-provisioning/src/main/java/esa/mo/nanomind/impl/parameters_provisioning/CacheHandler.java
+++ b/nanomind-connector/parameters-provisioning/src/main/java/esa/mo/nanomind/impl/parameters_provisioning/CacheHandler.java
@@ -1,0 +1,143 @@
+/* ----------------------------------------------------------------------------
+ * Copyright (C) 2021      European Space Agency
+ *                         European Space Operations Centre
+ *                         Darmstadt
+ *                         Germany
+ * ----------------------------------------------------------------------------
+ * System                : ESA NanoSat MO Framework
+ * ----------------------------------------------------------------------------
+ * Licensed under European Space Agency Public License (ESA-PL) Weak Copyleft – v2.4
+ * You may not use this file except in compliance with the License.
+ *
+ * Except as expressly set forth in this License, the Software is provided to
+ * You on an "as is" basis and without warranties of any kind, including without
+ * limitation merchantability, fitness for a particular purpose, absence of
+ * defects or errors, accuracy or non-infringement of intellectual property rights.
+ * 
+ * See the License for the specific language governing permissions and
+ * limitations under the License. 
+ * ----------------------------------------------------------------------------
+ */
+package esa.mo.nanomind.impl.parameters_provisioning;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import org.ccsds.moims.mo.mal.structures.Attribute;
+import org.ccsds.moims.mo.mal.structures.Identifier;
+import esa.mo.nmf.nanosatmosupervisor.parameter.OBSWParameter;
+import esa.mo.nmf.nanosatmosupervisor.parameter.OBSWParameterValuesProvider;
+
+/**
+ * Provides OBSW parameter values through a caching mechanism. For a given parameter, it only
+ * returns a non-null value if a value for this parameter was previously cached.
+ *
+ * @author Tanguy Soto
+ */
+class CacheHandler extends OBSWParameterValuesProvider {
+
+  /**
+   * Map of OBSW parameter value by parameter name acting as our cache storage.
+   */
+  private final Map<Identifier, TimedAttributeValue> cache;
+
+  /*
+   * Cache configuration settings
+   */
+
+  /**
+   * Maximum time a parameter value should stay in the cache in seconds.
+   */
+  private long cachingTime = 10;
+
+  /**
+   * Creates a new instance of CacheHandler.
+   * 
+   * @param parameterMap
+   */
+  public CacheHandler(HashMap<Identifier, OBSWParameter> parameterMap) {
+    super(parameterMap);
+    cache = new HashMap<Identifier, TimedAttributeValue>();
+  }
+
+  /**
+   * Sets the maximum time a parameter value should stay in the cache in seconds.
+   * 
+   * @param cachingTime the time
+   */
+  public void setCachingTime(long cachingTime) {
+    this.cachingTime = cachingTime;
+  }
+
+  /**
+   * Returns true if the cached value of this parameter has to be refreshed according to the cache
+   * settings.
+   *
+   * @param identifier Name of the parameter
+   * @return A boolean
+   */
+  public synchronized boolean mustRefreshValue(Identifier identifier) {
+    // Value for this parameter has never been cached
+    if (!cache.containsKey(identifier)) {
+      return true;
+    }
+
+    long now = System.currentTimeMillis();
+
+    // This parameter value is outdated
+    if (now - cache.get(identifier).getLastUpdateTime().getTime() > cachingTime * 1000) {
+      return true;
+    }
+
+    // No need to refresh, cached value is still valid.
+    return false;
+  }
+
+  /**
+   * Updates the last request time of this parameter to the time of the call.
+   * 
+   * @param identifier Name of the parameter
+   */
+  public synchronized void updateLastRequestTime(Identifier identifier) {
+    if (!cache.containsKey(identifier)) {
+      return;
+    }
+    cache.get(identifier).updateLastRequestTime();
+  }
+
+  /**
+   * Returns the date and time at which the parameter was last requested.
+   *
+   * @param identifier Name of the parameter
+   * @return A Date object or null if the parameter was never requested before
+   */
+  public synchronized Date getLastRequestTime(Identifier identifier) {
+    if (!cache.containsKey(identifier)) {
+      return null;
+    }
+    return cache.get(identifier).getLastRequestTime();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public synchronized Attribute getValue(Identifier identifier) {
+    if (!cache.containsKey(identifier)) {
+      return null;
+    }
+    return cache.get(identifier).getValue();
+  }
+
+  /**
+   * Caches a value for a given OBSW parameter name
+   *
+   * @param value Value to cache
+   * @param identifier Name of the parameter
+   */
+  public synchronized void cacheValue(Attribute value, Identifier identifier) {
+    if (!cache.containsKey(identifier)) {
+      cache.put(identifier, new TimedAttributeValue(value));
+    } else {
+      cache.get(identifier).setValue(value);
+    }
+  }
+}

--- a/nanomind-connector/parameters-provisioning/src/main/java/esa/mo/nanomind/impl/parameters_provisioning/ConfigurationHelper.java
+++ b/nanomind-connector/parameters-provisioning/src/main/java/esa/mo/nanomind/impl/parameters_provisioning/ConfigurationHelper.java
@@ -1,0 +1,58 @@
+/* ----------------------------------------------------------------------------
+ * Copyright (C) 2021      European Space Agency
+ *                         European Space Operations Centre
+ *                         Darmstadt
+ *                         Germany
+ * ----------------------------------------------------------------------------
+ * System                : ESA NanoSat MO Framework
+ * ----------------------------------------------------------------------------
+ * Licensed under European Space Agency Public License (ESA-PL) Weak Copyleft – v2.4
+ * You may not use this file except in compliance with the License.
+ *
+ * Except as expressly set forth in this License, the Software is provided to
+ * You on an "as is" basis and without warranties of any kind, including without
+ * limitation merchantability, fitness for a particular purpose, absence of
+ * defects or errors, accuracy or non-infringement of intellectual property rights.
+ * 
+ * See the License for the specific language governing permissions and
+ * limitations under the License. 
+ * ----------------------------------------------------------------------------
+ */
+package esa.mo.nanomind.impl.parameters_provisioning;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Helper functions to load configuration (system) properties.
+ * 
+ * @author Tangy Soto
+ */
+public class ConfigurationHelper {
+  private static final Logger LOGGER = Logger.getLogger(ConfigurationHelper.class.getName());
+
+  /**
+   * Tries to get a system property and parse it as an Integer.
+   * 
+   * @param propertyKey The property key
+   * @param defaultValue Default value to return if the property is not found
+   * @return the parsed system property
+   */
+  public static int getIntegerProperty(String propertyKey, int defaultValue) {
+    String propertyValue = System.getProperty(propertyKey);
+    if (propertyValue != null) {
+      try {
+        return Integer.parseInt(propertyValue);
+      } catch (NumberFormatException e) {
+        LOGGER.log(Level.WARNING,
+            String.format("Error parsing properties %s to Integer, defaulting to %d", propertyKey,
+                defaultValue),
+            e);
+        return defaultValue;
+      }
+    }
+    LOGGER.log(Level.WARNING,
+        String.format("Properties %s not found, defaulting to %d", propertyKey, defaultValue));
+    return defaultValue;
+  }
+}

--- a/nanomind-connector/parameters-provisioning/src/main/java/esa/mo/nanomind/impl/parameters_provisioning/LimitedNanomindAggregationConsumer.java
+++ b/nanomind-connector/parameters-provisioning/src/main/java/esa/mo/nanomind/impl/parameters_provisioning/LimitedNanomindAggregationConsumer.java
@@ -1,0 +1,221 @@
+/* ----------------------------------------------------------------------------
+ * Copyright (C) 2021      European Space Agency
+ *                         European Space Operations Centre
+ *                         Darmstadt
+ *                         Germany
+ * ----------------------------------------------------------------------------
+ * System                : ESA NanoSat MO Framework
+ * ----------------------------------------------------------------------------
+ * Licensed under European Space Agency Public License (ESA-PL) Weak Copyleft – v2.4
+ * You may not use this file except in compliance with the License.
+ *
+ * Except as expressly set forth in this License, the Software is provided to
+ * You on an "as is" basis and without warranties of any kind, including without
+ * limitation merchantability, fitness for a particular purpose, absence of
+ * defects or errors, accuracy or non-infringement of intellectual property rights.
+ * 
+ * See the License for the specific language governing permissions and
+ * limitations under the License. 
+ * ----------------------------------------------------------------------------
+ */
+package esa.mo.nanomind.impl.parameters_provisioning;
+
+import java.net.MalformedURLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.ccsds.moims.mo.mal.MALException;
+import esa.mo.helpertools.connections.SingleConnectionDetails;
+import esa.mo.nanomind.impl.consumer.AggregationNanomindConsumerServiceImpl;
+import esa.opssat.nanomind.mc.aggregation.consumer.AggregationStub;
+
+/**
+ * Decorator for the AggregationNanomindConsumerServiceImpl to limit the rate at which it can be
+ * queried.
+ * 
+ * @author Tanguy Soto
+ */
+class LimitedNanomindAggregationConsumer {
+  /**
+   * Maximum requests (TC sent to the Nanomind) per seconds.
+   */
+  private int MAX_QUERY_RATE = 7;
+
+  /**
+   * Our sliding window query rate limiter.
+   */
+  private SlidingWindowRateLimiter rateLimiter;
+
+  /**
+   * Whether we are currently limiting the query rate or not.
+   */
+  private boolean limitRate;
+
+  AggregationNanomindConsumerServiceImpl aggConsumerServiceImpl;
+
+  public LimitedNanomindAggregationConsumer(SingleConnectionDetails connectionDetails)
+      throws MALException, MalformedURLException {
+    aggConsumerServiceImpl = new AggregationNanomindConsumerServiceImpl(connectionDetails);
+    loadProperties();
+    initRateLimiter();
+  }
+
+  /**
+   * Load the system properties that we need.
+   */
+  private void loadProperties() {
+    //  Query rate
+    String queryRateProp = "nmf.supervisor.parameter.valuesprovider.nanomind.maxQueryRate";
+    MAX_QUERY_RATE = ConfigurationHelper.getIntegerProperty(queryRateProp, MAX_QUERY_RATE);
+  }
+
+  /**
+   * Initializes our rate limiter.
+   */
+  private void initRateLimiter() {
+    limitRate = true;
+    rateLimiter = new SlidingWindowRateLimiter(MAX_QUERY_RATE, 1000, 100);
+  }
+
+  /**
+   * Disable the rate limiter until enabled again.
+   */
+  public void enableRateLimiter() {
+    limitRate = true;
+  }
+
+  /**
+   * Enable the rate limiter until disabled again.
+   */
+  public void disableRateLimiter() {
+    limitRate = false;
+  }
+
+  /**
+   * @return The nanomind aggregation stub
+   * @throws QueryRateExceededException if the rate limiter is enabled and we are currently over the
+   *         limit
+   */
+  public AggregationStub getAggregationNanomindStub() throws QueryRateExceededException {
+    if (limitRate && !rateLimiter.allowQuery()) {
+      throw new QueryRateExceededException(
+          String.format("Rate of %d query/s exceeded", MAX_QUERY_RATE));
+    }
+    return aggConsumerServiceImpl.getAggregationNanomindStub();
+  }
+
+  /**
+   * Exception raised when the rate limiter is enabled and we are over the limit.
+   * 
+   * @author Tanguy Soto
+   */
+  public class QueryRateExceededException extends Exception {
+    private static final long serialVersionUID = 6011021055757437002L;
+
+    public QueryRateExceededException(String errorMessage) {
+      super(errorMessage);
+    }
+  }
+
+  /**
+   * Simple rate limiter using a sliding window.
+   * 
+   * @author Tanguy Soto
+   */
+  private class SlidingWindowRateLimiter {
+
+    /**
+     * Number of queries allowed per time window
+     */
+    private final int MAX_QUERIES;
+
+    /**
+     * The time window (in milliseconds)
+     */
+    private final int TIME_WINDOW_MS;
+
+    /**
+     * Size of the intervals (in milliseconds) at which the windows slides
+     */
+    private final int INTERVAL_MS;
+
+    /**
+     * Queries count for each interval of the time window
+     */
+    private Map<Long, Integer> countsPerInterval;
+
+    /**
+     * Total queries count of the current time window
+     */
+    private int totalCounts;
+
+    /**
+     * Creates a new SlidingWindowRateLimiter.
+     * 
+     * @param maxQueries Number of queries allowed per time window
+     * @param timeWindowMs The time window (in milliseconds)
+     * @param intervalMs Size of the intervals (in milliseconds) at which the windows slides.
+     *        Smaller intervals provide better accuracy in rate limiting but consume more memory.
+     */
+    public SlidingWindowRateLimiter(int maxQueries, int timeWindowMs, int intervalMs) {
+      this.MAX_QUERIES = maxQueries;
+      this.TIME_WINDOW_MS = timeWindowMs;
+      this.INTERVAL_MS = intervalMs;
+
+      this.countsPerInterval = new HashMap<Long, Integer>();
+      this.totalCounts = 0;
+    }
+
+    /**
+     * @return true if a query is allowed at the time of call, false if the query rate is already
+     *         over the limit
+     */
+    public synchronized boolean allowQuery() {
+      long currentTimestamp = System.currentTimeMillis();
+
+      // update current interval queries count
+      long currentInterval = getInterval(currentTimestamp);
+      Integer currentCount = countsPerInterval.get(currentInterval);
+      if (currentCount == null) {
+        currentCount = 0;
+      }
+      countsPerInterval.put(currentInterval, currentCount + 1);
+
+      // update total window queries count
+      cleanOlderIntervals(currentTimestamp);
+      totalCounts++;
+
+      // return depending on total window queries count
+      if (totalCounts > MAX_QUERIES) {
+        return false;
+      }
+      return true;
+    }
+
+    /**
+     * @param timestamp The timestamp
+     * @return The interval in which the timestamp belongs to
+     */
+    private long getInterval(long timestamp) {
+      return (long) ((timestamp / INTERVAL_MS) * INTERVAL_MS);
+    }
+
+    /**
+     * Removes intervals that slid out of the window at the current timestamp.
+     * 
+     * @param currentTimestamp The timestamp
+     */
+    private void cleanOlderIntervals(long currentTimestamp) {
+      long oldestValidInterval = getInterval(currentTimestamp - this.TIME_WINDOW_MS);
+
+      List<Long> intervalsToDelete = countsPerInterval.keySet().stream()
+          .filter(interval -> interval < oldestValidInterval).collect(Collectors.toList());
+
+      for (long interval : intervalsToDelete) {
+        totalCounts -= this.countsPerInterval.get(interval);
+        countsPerInterval.remove(interval);
+      }
+    }
+  }
+}

--- a/nanomind-connector/parameters-provisioning/src/main/java/esa/mo/nanomind/impl/parameters_provisioning/NanomindAggregationsHandler.java
+++ b/nanomind-connector/parameters-provisioning/src/main/java/esa/mo/nanomind/impl/parameters_provisioning/NanomindAggregationsHandler.java
@@ -1,0 +1,579 @@
+/* ----------------------------------------------------------------------------
+ * Copyright (C) 2021      European Space Agency
+ *                         European Space Operations Centre
+ *                         Darmstadt
+ *                         Germany
+ * ----------------------------------------------------------------------------
+ * System                : ESA NanoSat MO Framework
+ * ----------------------------------------------------------------------------
+ * Licensed under European Space Agency Public License (ESA-PL) Weak Copyleft – v2.4
+ * You may not use this file except in compliance with the License.
+ *
+ * Except as expressly set forth in this License, the Software is provided to
+ * You on an "as is" basis and without warranties of any kind, including without
+ * limitation merchantability, fitness for a particular purpose, absence of
+ * defects or errors, accuracy or non-infringement of intellectual property rights.
+ * 
+ * See the License for the specific language governing permissions and
+ * limitations under the License. 
+ * ----------------------------------------------------------------------------
+ */
+package esa.mo.nanomind.impl.parameters_provisioning;
+
+import java.math.BigInteger;
+import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.ccsds.moims.mo.mal.MALException;
+import org.ccsds.moims.mo.mal.MALInteractionException;
+import org.ccsds.moims.mo.mal.structures.Duration;
+import org.ccsds.moims.mo.mal.structures.Identifier;
+import org.ccsds.moims.mo.mal.structures.IdentifierList;
+import org.ccsds.moims.mo.mal.structures.LongList;
+import org.ccsds.moims.mo.mal.structures.URI;
+import esa.mo.helpertools.connections.SingleConnectionDetails;
+import esa.mo.nanomind.impl.parameters_provisioning.LimitedNanomindAggregationConsumer.QueryRateExceededException;
+import esa.mo.nmf.nanosatmosupervisor.parameter.OBSWAggregation;
+import esa.mo.nmf.nanosatmosupervisor.parameter.OBSWParameter;
+import esa.opssat.nanomind.mc.aggregation.body.GetValueResponse;
+import esa.opssat.nanomind.mc.aggregation.structures.AggregationCategory;
+import esa.opssat.nanomind.mc.aggregation.structures.AggregationDefinition;
+import esa.opssat.nanomind.mc.aggregation.structures.AggregationDefinitionList;
+import esa.opssat.nanomind.mc.aggregation.structures.AggregationReference;
+import esa.opssat.nanomind.mc.aggregation.structures.AggregationReferenceList;
+import esa.opssat.nanomind.mc.aggregation.structures.AggregationValue;
+import esa.opssat.nanomind.mc.aggregation.structures.AggregationValueList;
+import esa.opssat.nanomind.mc.aggregation.structures.factory.AggregationCategoryFactory;
+
+/**
+ * Provides OBSW parameter values by consuming the Nanomind aggregation service. Aggregation service
+ * is used with restrictions to avoid overloading the Nanomind.
+ * 
+ * @author Tanguy Soto
+ *
+ */
+class NanomindAggregationsHandler {
+  private static final Logger LOGGER =
+      Logger.getLogger(NanomindAggregationsHandler.class.getName());
+
+  /**
+   * Maximum number of parameters in one aggregation
+   */
+  private int PARAMS_PER_AGGREGATION = 8;
+
+  /*
+   * Maximum number of aggregation that we can define in the Nanomind.
+   */
+  private int MAX_DEFINABLE_AGGREGATION = 100;
+
+  /**
+   * Nanomind aggregation service consumer
+   */
+  private LimitedNanomindAggregationConsumer aggServiceCns;
+
+  private static final String NANOMIND_APID = "10"; // Default Nanomind APID (on 13 June 2016)
+  private static final String MAL_SPP_BINDINDING = "malspp"; // Use the SPP Implementation
+  private static final String SOURCE_ID = "0"; // OBSW supports any value. By default it is set to 0
+
+  /**
+   * Prefix for name of all aggregation definitions we generate.
+   */
+  private static final String AGG_DEF_NAME_PREFIX = "Z";
+
+  /**
+   * Identifier of cleaned aggregations that are available again after all their parameters where
+   * removed from them because they were not used anymore.
+   */
+  private List<String> aggsToReUse = new ArrayList<>();
+
+  /**
+   * List of the aggregations currently defined by this class in the Nanomind.
+   */
+  private List<OBSWAggregation> nanomindDefinitions = new ArrayList<>();
+
+  /**
+   * False until we leaned potential leftovers aggregations definitions from the Nanomind.
+   */
+  private boolean isInitialized = false;
+
+  public NanomindAggregationsHandler() throws MALException, MalformedURLException {
+    loadProperties();
+    initAggregationServiceConsumer();
+  }
+
+  /**
+   * Load the system properties that we need.
+   */
+  private void loadProperties() {
+    // Parameters per aggregation
+    String paramsPerAggregationProp =
+        "nmf.supervisor.parameter.valuesprovider.nanomind.paramsPerAggregation";
+    PARAMS_PER_AGGREGATION =
+        ConfigurationHelper.getIntegerProperty(paramsPerAggregationProp, PARAMS_PER_AGGREGATION);
+
+    // Max definable aggregations
+    String maxDefinableAggregationsProp =
+        "nmf.supervisor.parameter.valuesprovider.nanomind.maxDefinableAggregations";
+    MAX_DEFINABLE_AGGREGATION = ConfigurationHelper.getIntegerProperty(maxDefinableAggregationsProp,
+        MAX_DEFINABLE_AGGREGATION);
+  }
+
+  /**
+   * Initializes the Nanomind aggregation service consumer
+   */
+  private void initAggregationServiceConsumer() throws MALException, MalformedURLException {
+    // Connection details to Nanomind aggregation service
+    SingleConnectionDetails details = new SingleConnectionDetails();
+    IdentifierList domain = new IdentifierList();
+    domain.add(new Identifier("OPSSAT"));
+    details.setDomain(domain);
+    URI brokerUri = null;
+    details.setBrokerURI(brokerUri);
+    details.setProviderURI(MAL_SPP_BINDINDING + ":247/" + NANOMIND_APID + "/" + SOURCE_ID);
+
+    aggServiceCns = new LimitedNanomindAggregationConsumer(details);
+  }
+
+  /**
+   * Calls the getValue operation of the Nanomind aggregation service for the given aggregation.
+   *
+   * @param aggId The aggregation ID
+   * @return the aggregation value or null in case a MAL exception was raised
+   */
+  private AggregationValue getNanomindAggregationValue(long aggId) {
+    LongList aggIds = new LongList();
+    aggIds.add(aggId);
+    try {
+      GetValueResponse valueResponse = aggServiceCns.getAggregationNanomindStub().getValue(aggIds);
+      LOGGER.log(Level.FINE,
+          String.format("Agg. value for agg. id %d fetched from Nanomind", aggId));
+
+      AggregationValueList aggValueList = valueResponse.getBodyElement1();
+      AggregationValue aggValue = aggValueList.get(0);
+      return aggValue;
+    } catch (MALInteractionException | MALException e) {
+      LOGGER.log(Level.SEVERE,
+          "Error while calling getValue operation of Nanomind aggregation service", e);
+    } catch (QueryRateExceededException e) {
+      LOGGER.log(Level.SEVERE, e.getMessage());
+    }
+
+    return null;
+  }
+
+  /**
+   * Assign the given OBSW parameter to an aggregation in the Nanomind. If the limit of aggregations
+   * definition is reached or a problem occured, the parameter aggregation's is set to null.
+   *
+   * @param obswParameter The parameter we want to add to an aggregation
+   */
+  private void assignAggregationToParameter(OBSWParameter obswParameter) {
+    boolean isAssigned = false;
+    OBSWAggregation obswAgg = findAvailableAggregation();
+
+    // No existing aggregation can hold this parameter
+    if (obswAgg == null) {
+      obswAgg = createAggregation();
+      // We had room for a new aggregation
+      if (obswAgg != null) {
+        obswAgg.getParameters().add(obswParameter);
+        isAssigned = addDefinitionInNanomind(obswAgg);
+        // we successfully re-used an aggregation, we remove it from availability list
+        if (isAssigned && aggsToReUse.size() > 0) {
+          aggsToReUse.remove(aggsToReUse.size() - 1);
+        }
+      }
+    }
+    // Update an existing aggregation
+    else {
+      obswAgg.getParameters().add(obswParameter);
+      isAssigned = updateDefinitionInNanomind(obswAgg);
+      // Update failed, don't leave the parameter in our local definition
+      if (!isAssigned) {
+        obswAgg.getParameters().remove(obswAgg.getParameters().size() - 1);
+      }
+    }
+
+    if (isAssigned) {
+      obswParameter.setAggregation(obswAgg);
+    } else {
+      obswParameter.setAggregation(null);
+    }
+  }
+
+  /**
+   * Iterates over the aggregation already defined in the Nanomind to see if one is empty enough to
+   * include a new parameter.
+   *
+   * @return The aggregation or null if no aggregation is empty enough
+   */
+  private OBSWAggregation findAvailableAggregation() {
+    for (OBSWAggregation agg : nanomindDefinitions) {
+      if (agg.getParameters().size() < PARAMS_PER_AGGREGATION) {
+        return agg;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Creates a new aggregation.
+   *
+   * @return The aggregation or null if we reached the limit of aggregations definitions
+   */
+  private OBSWAggregation createAggregation() {
+    String aggIdentifier = nextAggregationIdentifier();
+    if (aggIdentifier == null) {
+      LOGGER.log(Level.WARNING,
+          "Max number of aggregation definitions reached, can't fetch value of new parameter");
+      return null;
+    }
+
+    OBSWAggregation newAggregation = new OBSWAggregation();
+    long aggId = aggregationIdentifier2AggregationId(aggIdentifier);
+    newAggregation.setId(aggId);
+    newAggregation.setDynamic(false);
+    newAggregation.setBuiltin(false);
+    newAggregation.setName(aggIdentifier);
+    newAggregation.setDescription("Gen. by supervisor");
+    newAggregation.setCategory(new AggregationCategoryFactory().createElement().toString());
+    newAggregation.setUpdateInterval(0);
+    newAggregation.setGenerationEnabled(false);
+    return newAggregation;
+  }
+
+  /**
+   * Updates an existing aggregation definition in the Nanomind.
+   *
+   * @param updatedAggregation The new version of the aggregation
+   * @return True if the update succeeded, false otherwise
+   */
+  private boolean updateDefinitionInNanomind(OBSWAggregation updatedAggregation) {
+    LongList ids = new LongList(1);
+    ids.add(updatedAggregation.getId());
+
+    AggregationDefinitionList aggList = toAggregationDefinitionList(updatedAggregation);
+
+    try {
+      aggServiceCns.getAggregationNanomindStub().updateDefinition(ids, aggList);
+      LOGGER.log(Level.FINE,
+          String.format("Agg. definition %s updated in Nanomind", updatedAggregation.getName()));
+      return true;
+    } catch (MALInteractionException | MALException e) {
+      // Aggregation couldn't be updated to the Nanomind
+      LOGGER.log(Level.SEVERE,
+          "Error while calling updateDefinition operation of Nanomind aggregation service", e);
+    } catch (QueryRateExceededException e) {
+      LOGGER.log(Level.SEVERE, e.getMessage());
+    }
+
+    return false;
+  }
+
+  /**
+   * Registers the given aggregation to the aggregation definitions in the Nanomind.
+   *
+   * @param newAggregation The aggregation to register
+   * @return True if the registration succeeded, false otherwise
+   */
+  private boolean addDefinitionInNanomind(OBSWAggregation newAggregation) {
+    AggregationDefinitionList list = toAggregationDefinitionList(newAggregation);
+
+    try {
+      aggServiceCns.getAggregationNanomindStub().addDefinition(list);
+      nanomindDefinitions.add(newAggregation);
+      LOGGER.log(Level.FINE,
+          String.format("Agg. definition %s added in Nanomind", newAggregation.getName()));
+      return true;
+    } catch (MALInteractionException | MALException e) {
+      // Aggregation couldn't be added to the Nanomind
+      LOGGER.log(Level.SEVERE,
+          "Error while calling addDefinition operation of Nanomind aggregation service", e);
+    } catch (QueryRateExceededException e) {
+      LOGGER.log(Level.FINE, e.getMessage());
+    }
+
+    return false;
+  }
+
+  /**
+   * Converts an OBSW aggregation object holder into an AggregationDefinitionList.
+   *
+   * @param obswAggregation The aggregation to convert
+   * @return The aggregation definition list
+   */
+  private AggregationDefinitionList toAggregationDefinitionList(OBSWAggregation obswAggregation) {
+    // Prepare list of parameters
+    LongList paramIds = new LongList();
+    for (OBSWParameter p : obswAggregation.getParameters()) {
+      paramIds.add(p.getId());
+    }
+
+    // Aggregation reference
+    AggregationReferenceList paramsSetList = new AggregationReferenceList();
+    AggregationReference paramsSet =
+        new AggregationReference(null, paramIds, new Duration(0), null);
+    paramsSetList.add(paramsSet);
+
+    // Aggregation definition
+    AggregationDefinition def = new AggregationDefinition(new Identifier(obswAggregation.getName()),
+        obswAggregation.getDescription(), AggregationCategory.GENERAL,
+        obswAggregation.isGenerationEnabled(), new Duration(obswAggregation.getUpdateInterval()),
+        false, new Duration(), paramsSetList);
+
+    // Finally the list
+    AggregationDefinitionList list = new AggregationDefinitionList();
+    list.add(def);
+
+    return list;
+  }
+
+  /**
+   * Fetches a new value for the given parameter by querying the Nanomind aggregation service. We
+   * define an aggregation including the parameter if not included in one yet and get the value of
+   * this aggregation.
+   * 
+   * @param obswParam The parameter
+   * @return The value of the containing aggregation or null if a problem occurred while fetching
+   */
+  public AggregationValue getNewValue(OBSWParameter obswParam) {
+    // If parameter is not included in an aggregation we assign it to one
+    if (obswParam.getAggregation() == null) {
+      assignAggregationToParameter(obswParam);
+    }
+    // If assignment failed (nanomind rejected update or creation of aggregation), give up
+    if (obswParam.getAggregation() == null) {
+      return null;
+    }
+
+    // Query the nanomind using the aggregation service
+    OBSWAggregation agg = obswParam.getAggregation();
+    AggregationValue aggValue = getNanomindAggregationValue(agg.getId());
+    return aggValue;
+  }
+
+  /**
+   * @return The next aggregation identifier to use at the moment of the call or null if we reached
+   *         the limit of aggregations definitions
+   */
+  private String nextAggregationIdentifier() {
+    // re-use a cleaned aggregation first
+    if (aggsToReUse.size() > 0) {
+      return aggsToReUse.get(aggsToReUse.size() - 1);
+    }
+    // generate a new one if not full
+    if (nanomindDefinitions.size() < MAX_DEFINABLE_AGGREGATION) {
+      return getAggregationIdentifier(nanomindDefinitions.size());
+    }
+    return null;
+  }
+
+  /**
+   * Generates a 4 letters aggregation identifier using from our local aggregation number.
+   * 
+   * @param i the local aggregation number between 0 and MAX_DEFINABLE_AGGREGATION - 1
+   * @return the aggregation identifier
+   */
+  private String getAggregationIdentifier(int i) {
+    return String.format(AGG_DEF_NAME_PREFIX + "%03d", i);
+  }
+
+  /**
+   * Converts an 4 letters aggregation identifier to its corresponding aggregation ID in the
+   * Nanomind. We know that on OPS-SAT Nanomind, an aggregation ID is equals to the long value
+   * represented by the aggregation identifier's characters.
+   * 
+   * @param identifier the identifier to convert
+   * @return the corresponding aggregation id
+   */
+  private long aggregationIdentifier2AggregationId(String identifier) {
+    if (identifier == null || identifier.length() != 4) {
+      LOGGER.log(Level.SEVERE, String.format(
+          "Trying to convert a wrong aggregation identifier: %s, 0 is returned", identifier));
+      return 0;
+    }
+    return new BigInteger(identifier.getBytes()).longValue();
+  }
+
+  /**
+   * Cleans all the aggregations that could have been defined by us in the Nanomind.
+   */
+  public void cleanAllAggregations() {
+    LOGGER.log(Level.INFO, "Cleaning aggregations definitions in Nanomind");
+    try {
+      // No query rate limit when cleaning
+      aggServiceCns.disableRateLimiter();
+
+      // Clean all possible aggregation definitions by batch of 10 definitions
+      int step = 10;
+      for (int i = 0; i < MAX_DEFINABLE_AGGREGATION + step; i += step) {
+        // get their ids
+        LongList aggIds = listDefinitionIds(i, i + step);
+        if (aggIds != null) {
+          // keep valid ones only
+          LongList validAggIds = new LongList();
+          for (Long id : aggIds) {
+            if (id != null) {
+              validAggIds.add(id);
+            }
+          }
+          if (validAggIds.size() > 0) {
+            aggServiceCns.getAggregationNanomindStub().removeDefinition(validAggIds);
+          }
+        }
+      }
+      isInitialized = true;
+      nanomindDefinitions = new ArrayList<>();
+      LOGGER.log(Level.INFO, "Cleaned aggregations definitions in Nanomind");
+    } catch (QueryRateExceededException | MALInteractionException | MALException e) {
+      LOGGER.log(Level.SEVERE, "Error cleaning Nanomind aggregation definitions", e);
+    } finally {
+      aggServiceCns.enableRateLimiter();
+    }
+  }
+
+  /**
+   * List aggregations definitions present in the Nanomind corresponding to the specified range of
+   * our local aggregations number.
+   * 
+   * @param start The start of the range (included)
+   * @param end The end of the range (excluded)
+   * @return The list or null if an error happened
+   */
+  private LongList listDefinitionIds(int start, int end) {
+    IdentifierList identifierList = new IdentifierList();
+    for (int i = start; i < end; i++) {
+      identifierList.add(new Identifier(getAggregationIdentifier(i)));
+    }
+
+    try {
+      LongList idsList = aggServiceCns.getAggregationNanomindStub().listDefinition(identifierList);
+      return idsList;
+    } catch (QueryRateExceededException | MALInteractionException | MALException e) {
+      LOGGER.log(Level.SEVERE,
+          "Error while calling listDefinition operation of Nanomind aggregation service", e);
+    }
+
+    return null;
+  }
+
+
+  /**
+   * Removes parameters that have not been requested for a while from the aggregations definitions
+   * in the Nanomind.
+   * 
+   * @param cache The cache handler to determine if the parameter is still used
+   * @param timeout The time (seconds) after which we consider a parameter is not used anymore
+   */
+  public void cleanParametersFromAggregations(CacheHandler cache, int timeout) {
+    LOGGER.log(Level.INFO, "Cleaning unused parameters from aggregations");
+
+    long now = System.currentTimeMillis();
+    List<OBSWAggregation> newNanomindDefinitions = new ArrayList<>();
+
+    try {
+      // No query rate limit when cleaning
+      aggServiceCns.disableRateLimiter();
+
+      // for each aggregation
+      for (OBSWAggregation agg : nanomindDefinitions) {
+        List<OBSWParameter> removedParams = new ArrayList<>();
+        List<OBSWParameter> keptParams = new ArrayList<>();
+
+        List<OBSWParameter> originalParams = new ArrayList<>(agg.getParameters());
+
+        // for each parameter
+        for (OBSWParameter param : agg.getParameters()) {
+          Identifier paramName = new Identifier(param.getName());
+          // check if parameter has not been requested for a while
+          Date lastRequestTime = cache.getLastRequestTime(paramName);
+          if (lastRequestTime == null || now - lastRequestTime.getTime() > timeout * 1000) {
+            removedParams.add(param);
+            param.setAggregation(null);
+          } else {
+            keptParams.add(param);
+          }
+        }
+
+        agg.getParameters().clear();
+        boolean modifSuccess = true;
+
+        // aggregation still has parameters
+        if (keptParams.size() > 0) {
+          // update it
+          agg.getParameters().addAll(keptParams);
+          if (removedParams.size() > 0) {
+            modifSuccess = updateDefinitionInNanomind(agg);
+          }
+          newNanomindDefinitions.add(agg);
+        }
+        // aggregation is now empty
+        else {
+          LongList aggIdList = new LongList();
+          aggIdList.add(agg.getId());
+          try {
+            aggServiceCns.getAggregationNanomindStub().removeDefinition(aggIdList);
+            aggsToReUse.add(agg.getName());
+            LOGGER.log(Level.FINE, String.format("Removed agg. definition %s", agg.getName()));
+          } catch (QueryRateExceededException | MALInteractionException | MALException e) {
+            LOGGER.log(Level.SEVERE, "Error cleaning Nanomind aggregation definition", e);
+            modifSuccess = false;
+            newNanomindDefinitions.add(agg);
+          }
+        }
+
+        // re-construct the aggregation locally as it was if failure
+        if (!modifSuccess) {
+          for (OBSWParameter removedParam : removedParams) {
+            removedParam.setAggregation(agg);
+          }
+          agg.getParameters().clear();
+          agg.getParameters().addAll(originalParams);
+        }
+      }
+    } finally {
+      // logDefinedAggregations();
+      aggServiceCns.enableRateLimiter();
+    }
+
+    // update final list of aggregations
+    nanomindDefinitions.clear();
+    nanomindDefinitions.addAll(newNanomindDefinitions);
+  }
+
+  /**
+   * Logs aggregation definitions present locally and in the nanomind.
+   */
+  private void logDefinedAggregations() {
+    String message = "Locally defined aggregations:\n";
+    for (OBSWAggregation obswAgg : nanomindDefinitions) {
+      message += (obswAgg.toString() + "\n");
+      for (OBSWParameter p : obswAgg.getParameters()) {
+        message += (p.toString() + "\n");
+      }
+    }
+    LOGGER.log(Level.INFO, message);
+
+    message = "Remotely (Nanomind) defined aggregations:\n";
+    LongList idsList = listDefinitionIds(0, 5);
+    if (idsList == null) {
+      message += "";
+    } else {
+      for (Long id : idsList) {
+        message += String.format("AggregationDefinition[ID=%s]\n", id);
+      }
+    }
+    LOGGER.log(Level.INFO, message);
+  }
+
+  /**
+   * @return the isInitialized
+   */
+  public boolean isInitialized() {
+    return isInitialized;
+  }
+}

--- a/nanomind-connector/parameters-provisioning/src/main/java/esa/mo/nanomind/impl/parameters_provisioning/NanomindParameterValuesProvider.java
+++ b/nanomind-connector/parameters-provisioning/src/main/java/esa/mo/nanomind/impl/parameters_provisioning/NanomindParameterValuesProvider.java
@@ -1,0 +1,246 @@
+/* ----------------------------------------------------------------------------
+ * Copyright (C) 2021      European Space Agency
+ *                         European Space Operations Centre
+ *                         Darmstadt
+ *                         Germany
+ * ----------------------------------------------------------------------------
+ * System                : ESA NanoSat MO Framework
+ * ----------------------------------------------------------------------------
+ * Licensed under European Space Agency Public License (ESA-PL) Weak Copyleft – v2.4
+ * You may not use this file except in compliance with the License.
+ *
+ * Except as expressly set forth in this License, the Software is provided to
+ * You on an "as is" basis and without warranties of any kind, including without
+ * limitation merchantability, fitness for a particular purpose, absence of
+ * defects or errors, accuracy or non-infringement of intellectual property rights.
+ * 
+ * See the License for the specific language governing permissions and
+ * limitations under the License. 
+ * ----------------------------------------------------------------------------
+ */
+package esa.mo.nanomind.impl.parameters_provisioning;
+
+import java.net.MalformedURLException;
+import java.util.HashMap;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.ccsds.moims.mo.mal.MALException;
+import org.ccsds.moims.mo.mal.structures.Attribute;
+import org.ccsds.moims.mo.mal.structures.Identifier;
+import esa.mo.nmf.nanosatmosupervisor.parameter.OBSWAggregation;
+import esa.mo.nmf.nanosatmosupervisor.parameter.OBSWParameter;
+import esa.mo.nmf.nanosatmosupervisor.parameter.OBSWParameterValuesProvider;
+import esa.opssat.nanomind.mc.aggregation.structures.AggregationValue;
+
+/**
+ * Provides OBSW parameter values by consuming the Nanomind aggregation service. Fetched values are
+ * placed in a cache and aggregation service is used with restrictions to avoid overloading the
+ * Nanomind.
+ *
+ * @author Tanguy Soto
+ */
+public class NanomindParameterValuesProvider extends OBSWParameterValuesProvider {
+  /**
+   * The logger
+   */
+  private static final Logger LOGGER =
+      Logger.getLogger(NanomindParameterValuesProvider.class.getName());
+
+  /**
+   * Time (seconds) a parameter value stays in the cache before requesting a new one from the
+   * Nanomind
+   */
+  private int CACHING_TIME = 10;
+
+  /**
+   * Interval (seconds) between attempts to clean aggregations definitions.
+   */
+  private int AGGREGATION_CLEANING_INTERVAL = 300;
+
+  /**
+   * Object handling caching of the values
+   */
+  private CacheHandler cacheHandler;
+
+  /**
+   * Nanomind aggregations handler.
+   */
+  private NanomindAggregationsHandler aggHandler;
+
+  /**
+   * Main lock to synchronize cache and aggregations manipulations.
+   */
+  private final ReentrantLock lock = new ReentrantLock();
+
+  /**
+   * Creates a new instance of CacheParameterValuesProvider.
+   * 
+   * @param parameterMap The map of OBSW parameters for which we have to provide values for
+   */
+  public NanomindParameterValuesProvider(HashMap<Identifier, OBSWParameter> parameterMap) {
+    super(parameterMap);
+    loadProperties();
+    initCacheHandler(parameterMap);
+    try {
+      initAggregationHandler();
+      scheduleCleaners();
+    } catch (MALException | MalformedURLException ex) {
+      LOGGER.log(Level.SEVERE, "Couldn't initialize the nanomind aggregation handler", ex);
+    }
+  }
+
+  /**
+   * Load the system properties that we need.
+   */
+  private void loadProperties() {
+    // Caching time
+    String cachingTimeProp = "nmf.supervisor.parameter.valuesprovider.nanomind.cachingTime";
+    CACHING_TIME = ConfigurationHelper.getIntegerProperty(cachingTimeProp, CACHING_TIME);
+
+    // Cleaning interval
+    String cleaningIntervalProp =
+        "nmf.supervisor.parameter.valuesprovider.nanomind.cleaningInterval";
+    AGGREGATION_CLEANING_INTERVAL =
+        ConfigurationHelper.getIntegerProperty(cleaningIntervalProp, AGGREGATION_CLEANING_INTERVAL);
+  }
+
+  /**
+   * Initializes the cache handler.
+   *
+   * @param parameterMap The map of OBSW parameters for which we have to provide values for
+   */
+  private void initCacheHandler(HashMap<Identifier, OBSWParameter> parameterMap) {
+    this.cacheHandler = new CacheHandler(parameterMap);
+    this.cacheHandler.setCachingTime(CACHING_TIME);
+  }
+
+  /**
+   * Initializes the Nanomind aggregation handler.
+   */
+  private void initAggregationHandler() throws MalformedURLException, MALException {
+    aggHandler = new NanomindAggregationsHandler();
+  }
+
+  /**
+   * Schedules a full clean of aggregations once only at startup and starts the periodic cleaning of
+   * parameters.
+   */
+  private void scheduleCleaners() {
+    // Full clean on startup
+    Timer timer = new Timer(true);
+    timer.schedule(new TimerTask() {
+      @Override
+      public void run() {
+        cleanAllAggregations();
+      }
+    }, 10000);
+
+    // Periodic cleaning
+    Timer timer2 = new Timer(true);
+    timer2.schedule(new TimerTask() {
+      @Override
+      public void run() {
+        cleanParametersFromAggregations();
+      }
+    }, AGGREGATION_CLEANING_INTERVAL * 1000, AGGREGATION_CLEANING_INTERVAL * 1000);
+  }
+
+  /**
+   * Cleans all the aggregations that could have been defined by us in the Nanomind.
+   */
+  public void cleanAllAggregations() {
+    lock.lock();
+    aggHandler.cleanAllAggregations();
+    lock.unlock();
+  }
+
+  /**
+   * Cleans parameters that have not been queried for a while from the aggregations definitions in
+   * the Nanomind.
+   */
+  private void cleanParametersFromAggregations() {
+    lock.lock();
+    aggHandler.cleanParametersFromAggregations(cacheHandler, AGGREGATION_CLEANING_INTERVAL);
+    lock.unlock();
+  }
+
+  /**
+   * Parses parameters values from an aggregation value and update the cached values for those
+   * parameters. Also returns the value of the parameter the aggregation was originally requested
+   * for.
+   *
+   * @param aggValue The aggregation value to parse
+   * @param agg Information about the OBSW aggregation
+   * @param identifier Name of the parameter the aggregation was requested for
+   * @return Value of the parameter the aggregation was requested for, null if the aggregation value
+   *         passed is null
+   */
+  private Attribute retrieveValueAndUpdateCache(AggregationValue aggValue, OBSWAggregation agg,
+      Identifier identifier) {
+    // An error occured when fetching the parameter's aggregation value
+    if (aggValue == null) {
+      return null;
+    }
+
+    Attribute paramValue = null;
+
+    // Parameter values are in the same order as in the aggregation definition
+    for (int i = 0; i < aggValue.getValues().size(); i++) {
+      Attribute value = aggValue.getValues().get(i).getRawValue();
+      Identifier paramName = new Identifier(agg.getParameters().get(i).getName());
+
+      // Return the requested parameter and update its request time
+      if (paramName.equals(identifier)) {
+        paramValue = value;
+      }
+      // A whole aggregation is returned, take the chance to update every parameters
+      cacheHandler.cacheValue(value, paramName);
+      LOGGER.log(Level.FINE, String.format("Cached value %s for parameter %s", value, paramName));
+    }
+
+    return paramValue;
+  }
+
+  /**
+   * Fetches a new value for the given parameter and updates it in the cache.
+   * 
+   * @param identifier The parameter name
+   * @return The value or null if the parameter is unknown or a problem occurred while fetching the
+   *         value
+   */
+  private Attribute getNewValue(Identifier identifier) {
+    // Parameter is unknown
+    if (!parameterMap.containsKey(identifier)) {
+      return null;
+    }
+
+    // Get a new value
+    OBSWParameter obswParam = parameterMap.get(identifier);
+    AggregationValue aggValue = aggHandler.getNewValue(obswParam);
+    return retrieveValueAndUpdateCache(aggValue, obswParam.getAggregation(), identifier);
+  }
+
+  @Override
+  public Attribute getValue(Identifier identifier) {
+    if (!aggHandler.isInitialized()) {
+      return null;
+    }
+
+    lock.lock();
+    try {
+      Attribute value = null;
+      if (cacheHandler.mustRefreshValue(identifier)) {
+        value = getNewValue(identifier);
+      }
+      value = cacheHandler.getValue(identifier);
+      cacheHandler.updateLastRequestTime(identifier);
+      return value;
+    } finally {
+      lock.unlock();
+      LOGGER.log(Level.FINE, "getValue(" + identifier + ") finished");
+    }
+  }
+}

--- a/nanomind-connector/parameters-provisioning/src/main/java/esa/mo/nanomind/impl/parameters_provisioning/TimedAttributeValue.java
+++ b/nanomind-connector/parameters-provisioning/src/main/java/esa/mo/nanomind/impl/parameters_provisioning/TimedAttributeValue.java
@@ -1,0 +1,99 @@
+/* ----------------------------------------------------------------------------
+ * Copyright (C) 2021      European Space Agency
+ *                         European Space Operations Centre
+ *                         Darmstadt
+ *                         Germany
+ * ----------------------------------------------------------------------------
+ * System                : ESA NanoSat MO Framework
+ * ----------------------------------------------------------------------------
+ * Licensed under European Space Agency Public License (ESA-PL) Weak Copyleft – v2.4
+ * You may not use this file except in compliance with the License.
+ *
+ * Except as expressly set forth in this License, the Software is provided to
+ * You on an "as is" basis and without warranties of any kind, including without
+ * limitation merchantability, fitness for a particular purpose, absence of
+ * defects or errors, accuracy or non-infringement of intellectual property rights.
+ * 
+ * See the License for the specific language governing permissions and
+ * limitations under the License. 
+ * ----------------------------------------------------------------------------
+ */
+package esa.mo.nanomind.impl.parameters_provisioning;
+
+import java.util.Date;
+import org.ccsds.moims.mo.mal.structures.Attribute;
+
+/**
+ * Wrapper around an Attribute and the times at which it was last updated and requested.
+ *
+ * @author Tanguy Soto
+ */
+class TimedAttributeValue {
+  /**
+   * The latest value
+   */
+  private Attribute value;
+
+  /**
+   * The latest update time of value
+   */
+  private Date lastUpdateTime;
+
+  /**
+   * The latest request time of value
+   */
+  private Date lastRequestTime;
+
+  /**
+   * Creates a new instance of TimedAttributeValue and sets the last update time to now.
+   *
+   * @param value The value
+   */
+  public TimedAttributeValue(Attribute value) {
+    this.value = value;
+    lastUpdateTime = new Date();
+    lastRequestTime = lastUpdateTime;
+  }
+
+  /**
+   * @return The latest value
+   */
+  public Attribute getValue() {
+    return value;
+  }
+
+  /**
+   * Sets the value and updates the latest update time.
+   * 
+   * @param value the new value to set
+   */
+  public void setValue(Attribute value) {
+    this.value = value;
+    lastUpdateTime = new Date();
+  }
+
+  /**
+   * Returns the latest update time of this value.
+   * 
+   * @return a Date containing the latest update time
+   */
+  public Date getLastUpdateTime() {
+    return lastUpdateTime;
+  }
+
+  /*
+   * Updates the last request time of this value to the time of the call.
+   */
+  public void updateLastRequestTime() {
+    lastRequestTime = new Date();
+  }
+
+  /**
+   * Returns the latest request time of this value.
+   * 
+   * @return a Date containing the latest request time
+   */
+  public Date getLastRequestTime() {
+    return lastRequestTime;
+  }
+}

--- a/nanomind-connector/pom.xml
+++ b/nanomind-connector/pom.xml
@@ -65,6 +65,7 @@
         <module>mo-xml</module>
         <module>mo-apis</module>
         <module>mo-consumers</module>
+        <module>parameters-provisioning</module>
     </modules>
 
 </project>

--- a/opssat-package/pom.xml
+++ b/opssat-package/pom.xml
@@ -178,6 +178,16 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>int.esa.nmf.core</groupId>
+      <artifactId>common-mo-adapter</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>int.esa.nmf.core</groupId>
+      <artifactId>space-mo-adapter</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>int.esa.nmf.sdk.examples.space</groupId>
       <artifactId>payloads-test</artifactId>
       <version>${project.version}</version>
@@ -196,6 +206,11 @@
       <groupId>int.esa.opssat.transport.dlr</groupId>
       <artifactId>malspp-encoding-opssat</artifactId>
       <version>1.0.1-FC</version>
+    </dependency>
+    <dependency>
+      <groupId>int.esa.nmf.mission.opssat.nanomind</groupId>
+      <artifactId>parameters-provisioning</artifactId>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
   <build>

--- a/opssat-package/src/main/resources/space-app-root/consumer.properties
+++ b/opssat-package/src/main/resources/space-app-root/consumer.properties
@@ -1,0 +1,9 @@
+#------------------------------------------------------------------------------------------------------
+# MO App configurations
+helpertools.configurations.MOappName=SpaceApp
+#------------------------------------------------------------------------------------------------------
+
+
+# All transport and settings properties are already set by the provider.properties file of your NMF app
+# and it's associated transport.properties and settings.properties files. If your NMF app appears to only
+# be a consumer, then provide all the missing properties here.

--- a/opssat-package/src/main/resources/space-common/settings.properties
+++ b/opssat-package/src/main/resources/space-common/settings.properties
@@ -7,3 +7,24 @@ helpertools.configurations.provider.DeviceName=SEPP
 
 # set the name of the MAL classes to use
 org.ccsds.moims.mo.mal.factory.class=esa.mo.mal.impl.MALContextFactoryImpl
+
+
+# === OBSW parameter values provider === #
+
+# class to use
+nmf.supervisor.parameter.valuesprovider.impl=esa.mo.nanomind.impl.parameters_provisioning.NanomindParameterValuesProvider
+
+# time (seconds) a parameter value stays in the cache before requesting a new one from the Nanomind
+nmf.supervisor.parameter.valuesprovider.nanomind.cachingTime=10
+
+# maximum number of aggregations that we can define in the Nanomind at the same time
+nmf.supervisor.parameter.valuesprovider.nanomind.maxDefinableAggregations=100
+
+# maximum number of parameters in one aggregation
+nmf.supervisor.parameter.valuesprovider.nanomind.paramsPerAggregation=8
+
+# maximum requests (TC sent to the Nanomind) per seconds
+nmf.supervisor.parameter.valuesprovider.nanomind.maxQueryRate=10
+
+# interval (seconds) at which we clean parameters not used anymore from aggregations in the Nanomind
+nmf.supervisor.parameter.valuesprovider.nanomind.cleaningInterval=300


### PR DESCRIPTION
New `parameters-provisioning` sub-project in `nanomind-connector`
- implements an  `OBSWParameterValuesProvider` (called `NanomindParameterValuesProvider`) according to [this other NMF pull request](https://github.com/esa/nanosat-mo-framework/pull/72) . It provides OBSW parameter values by consuming the Nanomind aggregation service. Fetched values are placed in a cache and aggregation service is used with restrictions to avoid overloading the Nanomind.