### PR TITLE
Bug #1043: NMF Supervisor appears to use SPP Encoder even communicating over MALTCP IPC

### DIFF
--- a/transport/dlr-malspp/transport/src/main/java/de/dlr/gsoc/mo/malspp/transport/SPPEndpoint.java
+++ b/transport/dlr-malspp/transport/src/main/java/de/dlr/gsoc/mo/malspp/transport/SPPEndpoint.java
@@ -365,7 +365,6 @@ public class SPPEndpoint implements MALEndpoint {
         try {
             if (isLocalDestination) {
                 try {
-                    ((SPPMessageBody) msg.getBody()).prepareInProcessBody();
                     transport.injectReceivedMessage(msg);
                     return;
                 } catch (final Exception ex) {


### PR DESCRIPTION
Problem is not what the bug's name suggests. The SPP encoder is not used by the TCP transport. Here is what happens:

1. During a PUB-SUB interaction, the MAL messages are sent to the brokers for both the primary and secondary transport, then brokers forward or not to the consumer the messages if there is an on-going subscription:
https://github.com/esa/mo-services-java/blob/bf86adf99a33ff2f15f169e6c6ed596b670b2542/apis/api-mal/src/main/java/org/ccsds/moims/mo/mal/provider/MALPublisherSet.java#L141-L143

2. However it seems that the SPP transport encodes the message body even to send it in-process to the broker (which generates the exception seen in the bug report since OPS-SAT SPP encoding cannot support blobs this big):
https://github.com/esa/nmf-mission-ops-sat/blob/4fb5d2e5278f383d98e2754ab25242a3d2612687/transport/dlr-malspp/transport/src/main/java/de/dlr/gsoc/mo/malspp/transport/SPPEndpoint.java#L366-L369
As this fails, the next publish for the TCP transport doesn't happen and the NMF APP never gets the published object (picture)

In theory, this encoding is not necessary but unclear comments seem to indicate that for this transport implementation it is:
- https://github.com/esa/nmf-mission-ops-sat/blob/a003354c8c34e217b2619f3776d2a7eaa9015b85/transport/dlr-malspp/transport/src/main/java/de/dlr/gsoc/mo/malspp/transport/SPPTransport.java#L719-L725
- https://github.com/esa/nmf-mission-ops-sat/blob/a003354c8c34e217b2619f3776d2a7eaa9015b85/transport/dlr-malspp/transport/src/main/java/de/dlr/gsoc/mo/malspp/transport/SPPMessageBody.java#L138-L146

**Solution**: Although it may have an impact somewhere else (the code is not very clear), commenting that line makes it work and the NMF APP gets the picture from the TCP transport when it's published since the SPP transport doesn't crash just before.