### PR TITLE
[bug] add conf. property for clock service adapter in hybrid sim mode

### DIFF
--- a/opssat-package/src/main/resources/space-supervisor-sim-root/platformsim.properties
+++ b/opssat-package/src/main/resources/space-supervisor-sim-root/platformsim.properties
@@ -7,6 +7,7 @@ adcs.adapter=esa.mo.platform.impl.provider.softsim.AutonomousADCSSoftSimAdapter
 optrx.adapter=esa.mo.platform.impl.provider.opssat.OpticalRxOPSSATAdapter
 sdr.adapter=esa.mo.platform.impl.provider.opssat.SDROPSSATAdapter
 pc.adapter=esa.mo.platform.impl.provider.opssat.PowerControlOPSSATAdapter
+clock.adapter=esa.mo.platform.impl.provider.softsim.ClockSoftSimAdapter
 
 
 # Below properties are used only in Camera sim mode


### PR DESCRIPTION
The property was missing in the hybrid simulation mode, leading to a null pointer exception when trying to instantiate the adapter for the clock service.