### PR TITLE
Issue 1190 [ADCS Adapter] Powercycle ADCS unit after failed init

### DIFF
--- a/opssat-package/src/main/resources/space-supervisor-opssat-root/settings.properties
+++ b/opssat-package/src/main/resources/space-supervisor-opssat-root/settings.properties
@@ -11,6 +11,14 @@ org.ccsds.moims.mo.mal.factory.class=esa.mo.mal.impl.MALContextFactoryImpl
 opssat.camera.port=/dev/cam_tty
 opssat.camera.blockdev=/dev/cam_sd
 
+# ADCS adapter properties
+opssat.adcs.iadcsWatchPeriodMS=10000
+opssat.adcs.iadcsInitBackoffMS=10000
+opssat.adcs.initFailedStopThreshold=3
+opssat.adcs.powercycleFailedStopThreshold=2
+opssat.adcs.powerdownWaitTimeMS=20000
+opssat.adcs.powerupWaitTimeMS=90000
+
 # === OBSW parameter values provider === #
 
 # class to use


### PR DESCRIPTION
https://gitlab.com/esa/NMF/nmf-issues/-/issues/1190

Fix AutonomousADCSOPSSATAdapter so that after 3 initialization
failures, the ADCS unit is powercycled up to 2 times.
Add all constants of AutonomousADCSOPSSATAdapter to the
file settings.properties.